### PR TITLE
Fix ipv4, ipv6, ethernet, and udpv4 tests for Python 3.

### DIFF
--- a/pcs/__init__.py
+++ b/pcs/__init__.py
@@ -568,7 +568,7 @@ class TypeLengthValueField(object):
 
         if self.bytewise is True:
             # Length should be encoded as a measure of bytes, not bits.
-            self.length.value /= 8
+            self.length.value //= 8
 
         [byte, byteBR] = self.type.encode(bytearray, self.type.value, byte, byteBR)
         [byte, byteBR] = self.length.encode(bytearray, self.length.value, byte, byteBR)

--- a/pcs/packets/ipv4.py
+++ b/pcs/packets/ipv4.py
@@ -235,7 +235,7 @@ class ipv4(pcs.Packet):
         tmppdata = pdata
         total = 0
         if len(tmppdata) % 2 == 1:
-            tmppdata += "\0"
+            tmppdata += b"\0"
         for i in range(len(tmppdata)//2):
             total += (struct.unpack("!H", tmppdata[2*i:2*i+2])[0])
         total = (total >> 16) + (total & 0xffff)

--- a/pcs/packets/ipv4.py
+++ b/pcs/packets/ipv4.py
@@ -236,7 +236,7 @@ class ipv4(pcs.Packet):
         total = 0
         if len(tmppdata) % 2 == 1:
             tmppdata += "\0"
-        for i in range(len(tmppdata)/2):
+        for i in range(len(tmppdata)//2):
             total += (struct.unpack("!H", tmppdata[2*i:2*i+2])[0])
         total = (total >> 16) + (total & 0xffff)
         total += total >> 16

--- a/tests/ethertest.py
+++ b/tests/ethertest.py
@@ -107,9 +107,9 @@ class etherTestCase(unittest.TestCase):
 #        ether = ethernet(packet)
         ether = file.readpkt()
         assert (ether != None)
-        self.assertEqual(ether.dst, "\x00\x10\xdb\x3a\x3a\x77",
+        self.assertEqual(ether.dst, b"\x00\x10\xdb\x3a\x3a\x77",
                          "dst not equal %s" % ether.src)
-        self.assertEqual(ether.src, "\x00\x0d\x93\x44\xfa\x62",
+        self.assertEqual(ether.src, b"\x00\x0d\x93\x44\xfa\x62",
                          "src not equal %s" % ether.dst)
         self.assertEqual(ether.type, 0x800, "type not equal %d" % ether.type)
 

--- a/tests/ipv4test.py
+++ b/tests/ipv4test.py
@@ -188,48 +188,48 @@ class ipTestCase(unittest.TestCase):
         #hd = hexdumper()
         #print hd.dump(ip.pdata)
 
-        expected = "\x46\x00\x00\x18\x00\x01\x40\x00" \
-                   "\x01\x02\x42\xC7\xC0\x00\x02\x01" \
-                   "\xE0\x00\x00\x16\x94\x04\x00\x00"
+        expected = bytes([0x46, 0x00, 0x00, 0x18, 0x00, 0x01, 0x40, 0x00,
+                          0x01, 0x02, 0x42, 0xC7, 0xC0, 0x00, 0x02, 0x01,
+                          0xE0, 0x00, 0x00, 0x16, 0x94, 0x04, 0x00, 0x00,])
         gotttted = ip.pdata
 
         self.assertEqual(expected, gotttted, "packet pdata not expected")
 
     def test_IN_LINKLOCAL(self):
         linklocal = inet_atol("169.254.12.34")
-        self.assert_(IN_LINKLOCAL(linklocal) == True)
+        self.assertTrue(IN_LINKLOCAL(linklocal))
         non_linklocal = inet_atol("127.0.0.0")
-        self.assert_(IN_LINKLOCAL(non_linklocal) == False)
+        self.assertFalse(IN_LINKLOCAL(non_linklocal))
 
     def test_IN_MULTICAST(self):
         mcast = inet_atol("239.0.12.34")
-        self.assert_(IN_MULTICAST(mcast) == True)
+        self.assertTrue(IN_MULTICAST(mcast))
         non_mcast = inet_atol("10.3.4.5")
-        self.assert_(IN_MULTICAST(non_mcast) == False)
+        self.assertFalse(IN_MULTICAST(non_mcast))
 
     def test_IN_LOCAL_GROUP(self):
         localgroup = inet_atol("224.0.0.251")
-        self.assert_(IN_LOCAL_GROUP(localgroup) == True)
+        self.assertTrue(IN_LOCAL_GROUP(localgroup))
         nonlocalgroup = inet_atol("239.0.12.34")
-        self.assert_(IN_LOCAL_GROUP(nonlocalgroup) == False)
+        self.assertFalse(IN_LOCAL_GROUP(nonlocalgroup))
 
     def test_IN_EXPERIMENTAL(self):
         classe = inet_atol("240.1.2.3")
-        self.assert_(IN_EXPERIMENTAL(classe) == True)
+        self.assertTrue(IN_EXPERIMENTAL(classe))
         non_classe = inet_atol("30.40.50.60")
-        self.assert_(IN_EXPERIMENTAL(non_classe) == False)
+        self.assertFalse(IN_EXPERIMENTAL(non_classe))
 
     def test_IN_PRIVATE(self):
         tens = inet_atol("10.20.30.40")
-        self.assert_(IN_PRIVATE(tens) == True)
+        self.assertTrue(IN_PRIVATE(tens))
         seventeens = inet_atol("172.16.254.3")
-        self.assert_(IN_PRIVATE(seventeens) == True)
+        self.assertTrue(IN_PRIVATE(seventeens))
         nineteens = inet_atol("192.168.123.45")
-        self.assert_(IN_PRIVATE(nineteens) == True)
+        self.assertTrue(IN_PRIVATE(nineteens))
         umpteens = inet_atol("192.0.2.1")
-        self.assert_(IN_PRIVATE(umpteens) == False)
+        self.assertFalse(IN_PRIVATE(umpteens))
         loopback = inet_atol("127.0.0.1")
-        self.assert_(IN_PRIVATE(loopback) == False)
+        self.assertFalse(IN_PRIVATE(loopback))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/ipv6test.py
+++ b/tests/ipv6test.py
@@ -135,7 +135,7 @@ class ip6TestCase(unittest.TestCase):
         ip = ipv6(packet[file.dloff:len(packet)])
         assert (ip != None)
 
-        test_string = "<IPv6: version: 6, traffic_class: 0, flow: 0, length: 16, next_header: 58, hop: 64, src: \'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\', dst: \'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\'>"
+        test_string = "<IPv6: version: 6, traffic_class: 0, flow: 0, length: 16, next_header: 58, hop: 64, src: b\'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\', dst: b\'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\'>"
 
         string = ip.println()
 

--- a/tests/udpv4test.py
+++ b/tests/udpv4test.py
@@ -131,25 +131,25 @@ class udpTestCase(unittest.TestCase):
         from pcs import inet_atol
         from pcs.packets.payload import payload
 
-        c = ethernet(src="\x01\x02\x03\x04\x05\x06",		\
-                     dst="\xff\xff\xff\xff\xff\xff") /		\
+        c = ethernet(src=b"\x01\x02\x03\x04\x05\x06",		\
+                     dst=b"\xff\xff\xff\xff\xff\xff") /		\
             ipv4(src=inet_atol("192.168.123.17"),		\
                  dst=inet_atol("192.0.2.2"), id=5235) /		\
             udp(sport=67, dport=68) /				\
-            payload("foobar\n")
+            payload(b"foobar\n")
 
         c.calc_lengths()
         c.calc_checksums()
         c.encode()
 
         expected = \
-        "\xFF\xFF\xFF\xFF\xFF\xFF\x01\x02" \
-        "\x03\x04\x05\x06\x08\x00\x45\x00" \
-        "\x00\x23\x14\x73\x00\x00\x40\x11" \
-        "\x68\x9B\xC0\xA8\x7B\x11\xC0\x00" \
-        "\x02\x02\x00\x43\x00\x44\x00\x0F" \
-        "\xC0\x48\x66\x6F\x6F\x62\x61\x72" \
-        "\x0A"
+        b"\xFF\xFF\xFF\xFF\xFF\xFF\x01\x02" \
+        b"\x03\x04\x05\x06\x08\x00\x45\x00" \
+        b"\x00\x23\x14\x73\x00\x00\x40\x11" \
+        b"\x68\x9B\xC0\xA8\x7B\x11\xC0\x00" \
+        b"\x02\x02\x00\x43\x00\x44\x00\x0F" \
+        b"\xC0\x48\x66\x6F\x6F\x62\x61\x72" \
+        b"\x0A"
 
         gotttted = c.pdata
         self.assertEqual(expected, gotttted, "test raw encoding")


### PR DESCRIPTION
- Switch to using integer division where appropriate.
- Replace deprecated assert_ calls with assertTrue/assertFalse as needed.
- Use bytes for expected packet payload rather than a string.
- Add bytes prefix to strings where needed.